### PR TITLE
Add Europe data foundation for birds demo

### DIFF
--- a/.github/workflows/validate-birds-europe-data.yml
+++ b/.github/workflows/validate-birds-europe-data.yml
@@ -1,0 +1,36 @@
+name: Validate birds Europe data
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "demos/birds/data/countries.json"
+      - "demos/birds/data/provider-registry.json"
+      - "demos/birds/data/europe-pilot.json"
+      - "demos/birds/ops/build_europe_pilot.py"
+      - "demos/birds/ops/validate_europe_data.py"
+      - ".github/workflows/validate-birds-europe-data.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build Europe pilot data
+        run: |
+          python demos/birds/ops/build_europe_pilot.py
+
+      - name: Validate Europe pilot data
+        run: |
+          python demos/birds/ops/validate_europe_data.py

--- a/demos/birds/data/countries.json
+++ b/demos/birds/data/countries.json
@@ -1,0 +1,41 @@
+{
+  "generated_at": "2026-05-22T05:36:47.334654+00:00",
+  "scope": "Europe pilot",
+  "countries": [
+    {
+      "code": "IE",
+      "name": "Ireland",
+      "priority": 1,
+      "status": "active",
+      "reason": "Current atlas origin and existing workflow base."
+    },
+    {
+      "code": "GB",
+      "name": "United Kingdom",
+      "priority": 2,
+      "status": "pilot",
+      "reason": "Neighbouring Atlantic biogeographic context and strong bird-recording culture."
+    },
+    {
+      "code": "FR",
+      "name": "France",
+      "priority": 3,
+      "status": "pilot",
+      "reason": "Major migration corridor between northern Europe, Atlantic systems, and the Mediterranean."
+    },
+    {
+      "code": "DE",
+      "name": "Germany",
+      "priority": 4,
+      "status": "pilot",
+      "reason": "Central European coverage and useful test case for inland species patterns."
+    },
+    {
+      "code": "IT",
+      "name": "Italy",
+      "priority": 5,
+      "status": "pilot",
+      "reason": "Mediterranean and Alpine migration context, and strategically relevant for future expansion."
+    }
+  ]
+}

--- a/demos/birds/data/europe-pilot.json
+++ b/demos/birds/data/europe-pilot.json
@@ -1,0 +1,69 @@
+{
+  "generated_at": "2026-05-22T05:36:47.334654+00:00",
+  "app": "European Bird Radar",
+  "mode": "europe_data_foundation",
+  "coverage": {
+    "scope": "five-country pilot",
+    "country_count": 5,
+    "countries": [
+      "IE",
+      "GB",
+      "FR",
+      "DE",
+      "IT"
+    ]
+  },
+  "providers": [
+    {
+      "id": "local_atlas",
+      "name": "Local bird sound atlas",
+      "role": "sound_and_species_baseline",
+      "status": "active"
+    },
+    {
+      "id": "ebird",
+      "name": "eBird",
+      "role": "recent_observations",
+      "status": "planned"
+    },
+    {
+      "id": "gbif",
+      "name": "GBIF",
+      "role": "occurrence_and_taxonomy_context",
+      "status": "planned"
+    },
+    {
+      "id": "eurobirdportal",
+      "name": "EuroBirdPortal",
+      "role": "seasonal_and_migration_context",
+      "status": "planned"
+    },
+    {
+      "id": "protected_sites",
+      "name": "Protected sites layer",
+      "role": "sensitivity_and_context",
+      "status": "planned"
+    }
+  ],
+  "data_contract": {
+    "observation_fields": [
+      "species_code",
+      "common_name",
+      "scientific_name",
+      "country",
+      "region",
+      "observation_date",
+      "count",
+      "lat",
+      "lng",
+      "source",
+      "freshness"
+    ],
+    "status": "draft"
+  },
+  "notes": [
+    "This is a structural Europe-ready data layer.",
+    "Live external providers are not harvested in this foundation step.",
+    "The existing sound atlas remains the active baseline provider."
+  ]
+}

--- a/demos/birds/data/europe-validation.json
+++ b/demos/birds/data/europe-validation.json
@@ -1,0 +1,6 @@
+{
+  "status": "pass",
+  "checked_at": "2026-05-22T05:36:47.398962+00:00",
+  "scope": "birds_europe_data_foundation",
+  "warnings": []
+}

--- a/demos/birds/data/provider-registry.json
+++ b/demos/birds/data/provider-registry.json
@@ -1,0 +1,63 @@
+{
+  "generated_at": "2026-05-22T05:36:47.334654+00:00",
+  "providers": [
+    {
+      "id": "local_atlas",
+      "name": "Local bird sound atlas",
+      "role": "sound_and_species_baseline",
+      "status": "active",
+      "data_type": [
+        "species",
+        "audio",
+        "attribution"
+      ],
+      "update_frequency": "daily_or_manual"
+    },
+    {
+      "id": "ebird",
+      "name": "eBird",
+      "role": "recent_observations",
+      "status": "planned",
+      "data_type": [
+        "recent_observations",
+        "hotspots",
+        "regional_lists"
+      ],
+      "update_frequency": "daily"
+    },
+    {
+      "id": "gbif",
+      "name": "GBIF",
+      "role": "occurrence_and_taxonomy_context",
+      "status": "planned",
+      "data_type": [
+        "occurrences",
+        "taxonomy",
+        "species_context"
+      ],
+      "update_frequency": "weekly_or_monthly"
+    },
+    {
+      "id": "eurobirdportal",
+      "name": "EuroBirdPortal",
+      "role": "seasonal_and_migration_context",
+      "status": "planned",
+      "data_type": [
+        "seasonal_patterns",
+        "migration_context"
+      ],
+      "update_frequency": "manual_or_periodic"
+    },
+    {
+      "id": "protected_sites",
+      "name": "Protected sites layer",
+      "role": "sensitivity_and_context",
+      "status": "planned",
+      "data_type": [
+        "protected_areas",
+        "habitat_context"
+      ],
+      "update_frequency": "monthly_or_manual"
+    }
+  ]
+}

--- a/demos/birds/ops/build_europe_pilot.py
+++ b/demos/birds/ops/build_europe_pilot.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+
+COUNTRIES_PATH = DATA / "countries.json"
+PROVIDERS_PATH = DATA / "provider-registry.json"
+OUTPUT_PATH = DATA / "europe-pilot.json"
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc).isoformat()
+
+    countries = load_json(COUNTRIES_PATH)
+    providers = load_json(PROVIDERS_PATH)
+
+    countries["generated_at"] = now
+    providers["generated_at"] = now
+
+    pilot = {
+        "generated_at": now,
+        "app": "European Bird Radar",
+        "mode": "europe_data_foundation",
+        "coverage": {
+            "scope": "five-country pilot",
+            "country_count": len(countries.get("countries", [])),
+            "countries": [country["code"] for country in countries.get("countries", [])],
+        },
+        "providers": [
+            {
+                "id": provider["id"],
+                "name": provider["name"],
+                "role": provider["role"],
+                "status": provider["status"],
+            }
+            for provider in providers.get("providers", [])
+        ],
+        "data_contract": {
+            "observation_fields": [
+                "species_code",
+                "common_name",
+                "scientific_name",
+                "country",
+                "region",
+                "observation_date",
+                "count",
+                "lat",
+                "lng",
+                "source",
+                "freshness",
+            ],
+            "status": "draft"
+        },
+        "notes": [
+            "This is a structural Europe-ready data layer.",
+            "Live external providers are not harvested in this foundation step.",
+            "The existing sound atlas remains the active baseline provider."
+        ]
+    }
+
+    COUNTRIES_PATH.write_text(
+        json.dumps(countries, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    PROVIDERS_PATH.write_text(
+        json.dumps(providers, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    OUTPUT_PATH.write_text(
+        json.dumps(pilot, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Wrote {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/birds/ops/validate_europe_data.py
+++ b/demos/birds/ops/validate_europe_data.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+
+REQUIRED_FILES = [
+    DATA / "countries.json",
+    DATA / "provider-registry.json",
+    DATA / "europe-pilot.json",
+]
+
+REQUIRED_COUNTRIES = {"IE", "GB", "FR", "DE", "IT"}
+REQUIRED_PROVIDERS = {"local_atlas", "ebird", "gbif", "eurobirdportal", "protected_sites"}
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def main() -> None:
+    warnings: list[str] = []
+
+    for path in REQUIRED_FILES:
+        if not path.exists():
+            raise SystemExit(f"Missing required Europe data file: {path}")
+
+    countries_payload = load_json(DATA / "countries.json")
+    providers_payload = load_json(DATA / "provider-registry.json")
+    pilot_payload = load_json(DATA / "europe-pilot.json")
+
+    country_codes = {
+        country.get("code")
+        for country in countries_payload.get("countries", [])
+        if isinstance(country, dict)
+    }
+
+    missing_countries = REQUIRED_COUNTRIES - country_codes
+    if missing_countries:
+        warnings.append(f"Missing pilot countries: {sorted(missing_countries)}")
+
+    provider_ids = {
+        provider.get("id")
+        for provider in providers_payload.get("providers", [])
+        if isinstance(provider, dict)
+    }
+
+    missing_providers = REQUIRED_PROVIDERS - provider_ids
+    if missing_providers:
+        warnings.append(f"Missing planned providers: {sorted(missing_providers)}")
+
+    coverage = pilot_payload.get("coverage", {})
+    if coverage.get("country_count") != len(country_codes):
+        warnings.append("europe-pilot.json country_count does not match countries.json.")
+
+    validation = {
+        "status": "pass" if not warnings else "warning",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "birds_europe_data_foundation",
+        "warnings": warnings,
+    }
+
+    validation_path = DATA / "europe-validation.json"
+    validation_path.write_text(
+        json.dumps(validation, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Europe data validation: {validation['status']}")
+    for warning in warnings:
+        print(f"Warning: {warning}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the Europe-ready data foundation for /demos/birds/.

Changes:
- Adds five-country pilot coverage file
- Adds provider registry for local atlas, eBird, GBIF, EuroBirdPortal, and protected sites
- Adds generated europe-pilot.json data contract
- Adds Europe data validation script
- Adds GitHub Actions validation workflow

This does not yet harvest live external provider data. It prepares the app architecture so European expansion can be added without hard-coding providers into the front end.