### PR TITLE
Add eBird recent observations provider

### DIFF
--- a/.github/workflows/refresh-birds-observations.yml
+++ b/.github/workflows/refresh-birds-observations.yml
@@ -1,0 +1,40 @@
+name: Refresh birds observations
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 5 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build eBird recent observations
+        env:
+          EBIRD_API_KEY: ${{ secrets.EBIRD_API_KEY }}
+        run: |
+          python demos/birds/ops/build_ebird_recent.py
+
+      - name: Validate recent observations
+        run: |
+          python demos/birds/ops/validate_recent_observations.py
+
+      - name: Commit updated observations
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add demos/birds/data/recent-observations.json demos/birds/data/recent-observations-validation.json
+          git diff --cached --quiet || git commit -m "Refresh birds recent observations"
+          git push

--- a/demos/birds/data/recent-observations-validation.json
+++ b/demos/birds/data/recent-observations-validation.json
@@ -1,0 +1,9 @@
+{
+  "status": "pass",
+  "checked_at": "2026-05-22T05:43:51.048354+00:00",
+  "scope": "recent_observations",
+  "provider": "ebird",
+  "source_status": "missing_api_key",
+  "item_count": 0,
+  "warnings": []
+}

--- a/demos/birds/data/recent-observations.json
+++ b/demos/birds/data/recent-observations.json
@@ -1,0 +1,20 @@
+{
+  "generated_at": "2026-05-22T05:43:50.987693+00:00",
+  "provider": "ebird",
+  "status": "missing_api_key",
+  "coverage": {
+    "countries": [
+      "IE",
+      "GB",
+      "FR",
+      "DE",
+      "IT"
+    ],
+    "back_days": 7,
+    "max_results_per_country": 100
+  },
+  "items": [],
+  "warnings": [
+    "EBIRD_API_KEY is not set. Add it as a GitHub Actions repository secret before scheduled harvesting."
+  ]
+}

--- a/demos/birds/ops/build_ebird_recent.py
+++ b/demos/birds/ops/build_ebird_recent.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+
+COUNTRIES_PATH = DATA / "countries.json"
+OUTPUT_PATH = DATA / "recent-observations.json"
+
+EBIRD_ENDPOINT = "https://api.ebird.org/v2/data/obs/{region_code}/recent"
+
+MAX_RESULTS_PER_COUNTRY = 100
+BACK_DAYS = 7
+REQUEST_PAUSE_SECONDS = 1.0
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalise_observation(raw: dict[str, Any], country_code: str) -> dict[str, Any]:
+    return {
+        "species_code": raw.get("speciesCode"),
+        "common_name": raw.get("comName"),
+        "scientific_name": raw.get("sciName"),
+        "country": country_code,
+        "region": raw.get("locName"),
+        "observation_date": raw.get("obsDt"),
+        "count": raw.get("howMany"),
+        "lat": raw.get("lat"),
+        "lng": raw.get("lng"),
+        "source": "eBird",
+        "freshness": "recent_7_days",
+        "location_id": raw.get("locId"),
+        "observation_valid": raw.get("obsValid"),
+        "observation_reviewed": raw.get("obsReviewed"),
+    }
+
+
+def fetch_country(region_code: str, token: str) -> list[dict[str, Any]]:
+    params = urllib.parse.urlencode({
+        "back": BACK_DAYS,
+        "maxResults": MAX_RESULTS_PER_COUNTRY,
+    })
+
+    url = f"{EBIRD_ENDPOINT.format(region_code=region_code)}?{params}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "X-eBirdApiToken": token,
+            "User-Agent": "salmonofdoubt-birds-europe-provider/1.0 (+https://salmonofdoubt.github.io/demos/birds/)",
+        },
+    )
+
+    with urllib.request.urlopen(request, timeout=30) as response:
+        if response.status != 200:
+            raise RuntimeError(f"eBird returned HTTP {response.status} for {region_code}")
+        return json.loads(response.read().decode("utf-8"))
+
+
+def main() -> None:
+    DATA.mkdir(parents=True, exist_ok=True)
+
+    countries_payload = load_json(COUNTRIES_PATH)
+    countries = countries_payload.get("countries", [])
+
+    pilot_codes = [
+        country["code"]
+        for country in countries
+        if country.get("status") in {"active", "pilot"} and country.get("code")
+    ]
+
+    token = os.environ.get("EBIRD_API_KEY", "").strip()
+    generated_at = utc_now()
+
+    if not token:
+        payload = {
+            "generated_at": generated_at,
+            "provider": "ebird",
+            "status": "missing_api_key",
+            "coverage": {
+                "countries": pilot_codes,
+                "back_days": BACK_DAYS,
+                "max_results_per_country": MAX_RESULTS_PER_COUNTRY,
+            },
+            "items": [],
+            "warnings": [
+                "EBIRD_API_KEY is not set. Add it as a GitHub Actions repository secret before scheduled harvesting."
+            ],
+        }
+        OUTPUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print("Wrote recent-observations.json with missing_api_key status.")
+        return
+
+    items: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for code in pilot_codes:
+        try:
+            raw_items = fetch_country(code, token)
+            items.extend(normalise_observation(item, code) for item in raw_items)
+            print(f"{code}: {len(raw_items)} observations")
+        except Exception as exc:
+            warning = f"{code}: {exc}"
+            warnings.append(warning)
+            print(f"Warning: {warning}", file=sys.stderr)
+
+        time.sleep(REQUEST_PAUSE_SECONDS)
+
+    payload = {
+        "generated_at": generated_at,
+        "provider": "ebird",
+        "status": "pass" if not warnings else "warning",
+        "coverage": {
+            "countries": pilot_codes,
+            "back_days": BACK_DAYS,
+            "max_results_per_country": MAX_RESULTS_PER_COUNTRY,
+            "item_count": len(items),
+        },
+        "items": items,
+        "warnings": warnings,
+    }
+
+    OUTPUT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {OUTPUT_PATH} with {len(items)} observations.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/birds/ops/validate_recent_observations.py
+++ b/demos/birds/ops/validate_recent_observations.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+OBS_PATH = DATA / "recent-observations.json"
+VALIDATION_PATH = DATA / "recent-observations-validation.json"
+
+ALLOWED_STATUSES = {"pass", "warning", "missing_api_key"}
+
+REQUIRED_ITEM_FIELDS = [
+    "species_code",
+    "common_name",
+    "scientific_name",
+    "country",
+    "region",
+    "observation_date",
+    "lat",
+    "lng",
+    "source",
+    "freshness",
+]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def main() -> None:
+    if not OBS_PATH.exists():
+        raise SystemExit(f"Missing {OBS_PATH}")
+
+    payload = load_json(OBS_PATH)
+    warnings: list[str] = []
+
+    status = payload.get("status")
+    if status not in ALLOWED_STATUSES:
+        warnings.append(f"Unexpected status: {status}")
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise SystemExit("recent-observations.json items must be a list.")
+
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            warnings.append(f"Item {index} is not an object.")
+            continue
+
+        missing = [field for field in REQUIRED_ITEM_FIELDS if field not in item]
+        if missing:
+            warnings.append(f"Item {index} missing fields: {missing}")
+
+        if item.get("source") != "eBird":
+            warnings.append(f"Item {index} has unexpected source: {item.get('source')}")
+
+    validation = {
+        "status": "pass" if not warnings else "warning",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "recent_observations",
+        "provider": payload.get("provider"),
+        "source_status": status,
+        "item_count": len(items),
+        "warnings": warnings,
+    }
+
+    VALIDATION_PATH.write_text(
+        json.dumps(validation, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Recent-observations validation: {validation['status']}")
+    for warning in warnings:
+        print(f"Warning: {warning}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the first live European observation provider foundation for /demos/birds/.

Changes:
- Adds eBird recent-observations builder
- Adds recent-observations validation
- Adds generated recent-observations JSON
- Adds daily/manual GitHub Actions workflow for recent observations
- Uses EBIRD_API_KEY from GitHub Actions secrets

This prepares the birds demo for Europe-wide recent observation data without hard-coding provider logic into the front end.